### PR TITLE
adding space between # and text in comment

### DIFF
--- a/00-open-a-shapefile.Rmd
+++ b/00-open-a-shapefile.Rmd
@@ -63,15 +63,6 @@ on your computer to complete this lesson.
 
 {% include/_greyBox-wd-rscript.html %}
 
-
-**Vector Lesson Series:** This lesson is part of a lesson series on 
-[vector data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-vector-series).
-It is also part of a larger 
-[spatio-temporal Data Carpentry Workshop ]({{ site.baseurl }}self-paced-tutorials/spatio-temporal-workshop)
-that includes working with
-[raster data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-raster-series) 
-and [tabular time series in R ]({{ site.baseurl }}self-paced-tutorials/tabular-time-series).
-
 </div>
 
 ## About Vector Data
@@ -130,15 +121,15 @@ We will use the `rgdal` package to work with vector data in `R`. Notice that the
 
 ```{r load-libraries }
 
-#load required libraries
-#for vector work; sp package will load with rgdal.
+# load required libraries
+# for vector work; sp package will load with rgdal.
 library(rgdal)  
-#for metadata/attributes- vectors or rasters
+# for metadata/attributes- vectors or rasters
 library(raster) 
 
-#set working directory to the directory location on your computer where
-#you downloaded and unzipped the data files for the lesson
-#setwd("pathToDirHere")
+# set working directory to the directory location on your computer where
+# you downloaded and unzipped the data files for the lesson
+# setwd("pathToDirHere")
 ```
 
 The shapefiles that we will import are:
@@ -163,8 +154,8 @@ Let's import our AOI.
 
 ```{r Import-Shapefile}
 
-#Import a polygon shapefile: readOGR("path","fileName")
-#no extension needed as readOGR only imports shapefiles
+# Import a polygon shapefile: readOGR("path","fileName")
+# no extension needed as readOGR only imports shapefiles
 aoiBoundary_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV",
                             "HarClip_UTMZ18")
 
@@ -203,16 +194,16 @@ extent for ALL spatial objects in the shapefile.
 We can view shapefile metadata using the `class`, `crs` and `extent` methods:
 
 ```{r view-metadata }
-#view just the class for the shapefile
+# view just the class for the shapefile
 class(aoiBoundary_HARV)
 
-#view just the crs for the shapefile
+# view just the crs for the shapefile
 crs(aoiBoundary_HARV)
 
-#view just the extent for the shapefile
+# view just the extent for the shapefile
 extent(aoiBoundary_HARV)
 
-#view all metadata at same time
+# view all metadata at same time
 aoiBoundary_HARV
 ```
 
@@ -258,7 +249,7 @@ We view the attributes of a `SpatialPolygonsDataFrame` using `objectName@data`
 (e.g., `aoiBoundary_HARV@data`). 
 
 ``` {r Shapefile-attributes-2}
-#alternate way to view attributes 
+# alternate way to view attributes 
 aoiBoundary_HARV@data
 
 ```
@@ -273,7 +264,7 @@ includes the **class**, the number of **features**, the **extent**, and the
 `summary` show a preview of the `R` object **attributes**.
 
 ```{r shapefile-summary}
-#view a summary of metadata & attributes associated with the spatial object
+# view a summary of metadata & attributes associated with the spatial object
 summary(aoiBoundary_HARV)
 
 ```
@@ -284,7 +275,7 @@ Next, let's visualize the data in our `R` `spatialpolygonsdataframe` object usin
 `plot()`.
 
 ``` {r plot-shapefile}
-#create a plot of the shapefile
+# create a plot of the shapefile
 # 'lwd' sets the line width
 # 'col' sets internal color
 # 'border' sets line color
@@ -308,30 +299,30 @@ Answer the following questions:
 </div>
 
 ```{r import-point-line, echo=FALSE, results="hide" }
-#import line shapefile
+# import line shapefile
 lines_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV",layer = "HARV_roads")
-#import point shapefile
+# import point shapefile
 point_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV", layer="HARVtower_UTM18N")
 
-#1
+# 1
 class (lines_HARV)
 class (point_HARV)
 
-#2
+# 2
 crs(lines_HARV)
 extent(lines_HARV)
 crs(point_HARV)
 extent(point_HARV)
 
-#3 
+# 3 
 #lines_HARV contains only lines and point_HARV contains only 1 point
 
-#4 -> numerous ways to find this; lines_HARV=13,
+# 4 -> numerous ways to find this; lines_HARV=13,
 length(lines_HARV)  #easiest, but not previously taught
 lines_HARV  #look at 'features'
 attributes(lines_HARV)  #found in the $data section as above
 
-#Alternative code for 1-4: view metadata/attributes all at once
+# Alternative code for 1-4: view metadata/attributes all at once
 lines_HARV
 attributes(lines_HARV)
 
@@ -346,12 +337,12 @@ We can use `main=""` to give our plot a title. If we want the title to span two
 lines, we use `\n` where the line should break.
 
 ```{r plot-multiple-shapefiles }
-#Plot multiple shapefiles
+# Plot multiple shapefiles
 plot(aoiBoundary_HARV, col = "lightgreen", 
      main="NEON Harvard Forest\nField Site")
 plot(lines_HARV, add = TRUE)
 
-#use the pch element to adjust the symbology of the points
+# use the pch element to adjust the symbology of the points
 plot(point_HARV, add  = TRUE, pch = 19, col = "purple")
 ```
 
@@ -378,7 +369,7 @@ lessons.
 
 ```{r challenge-vector-raster-overlay, echo=FALSE }
 
-#import CHM
+# import CHM
 chm_HARV <- raster("NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif")
 
 plot(chm_HARV,

--- a/01-shapefile-attributes.Rmd
+++ b/01-shapefile-attributes.Rmd
@@ -64,14 +64,6 @@ preferably RStudio, loaded on your computer.
 
 {% include/_greyBox-wd-rscript.html %}
 
-**Vector Lesson Series:** This lesson is part of a lesson series on 
-[vector data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-vector-series).
-It is also part of a larger 
-[spatio-temporal Data Carpentry Workshop ]({{ site.baseurl }}self-paced-tutorials/spatio-temporal-workshop)
-that includes working with
-[raster data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-raster-series) 
-and [tabular time series in R ]({{ site.baseurl }}self-paced-tutorials/tabular-time-series).
-
 </div>
 
 ## Shapefile Metadata & Attributes
@@ -94,23 +86,23 @@ If you completed the
 lesson, you can skip this code.
 
 ```{r load-packages-data }
-#load packages
-#rgdal: for vector work; sp package should always load with rgdal. 
+# load packages
+# rgdal: for vector work; sp package should always load with rgdal. 
 library(rgdal)  
-#raster: for metadata/attributes- vectors or rasters
+# raster: for metadata/attributes- vectors or rasters
 library (raster)   
 
-#set working directory to data folder
-#setwd("pathToDirHere")
+# set working directory to data folder
+# setwd("pathToDirHere")
 
-#Import a polygon shapefile 
+# Import a polygon shapefile 
 aoiBoundary_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                             "HarClip_UTMZ18")
 
-#Import a line shapefile
+# Import a line shapefile
 lines_HARV <- readOGR( "NEON-DS-Site-Layout-Files/HARV/", "HARV_roads")
 
-#Import a point shapefile 
+# Import a point shapefile 
 point_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                       "HARVtower_UTM18N")
 
@@ -131,20 +123,20 @@ in.
 Let's explore the metadata for our `point_HARV` object. 
 
 ```{r view-shapefile-metadata }
-#view class
+# view class
 class(x = point_HARV)
 
 # x= isn't actually needed; it just specifies which object
-#view features count
+# view features count
 length(point_HARV)
 
-#view crs - note - this only works with the raster package loaded
+# view crs - note - this only works with the raster package loaded
 crs(point_HARV)
 
-#view extent- note - this only works with the raster package loaded
+# view extent- note - this only works with the raster package loaded
 extent(point_HARV)
 
-#view metadata summary
+# view metadata summary
 point_HARV
 ```
 
@@ -177,10 +169,10 @@ the `data` slot with `objectName@data`. We can use the base `R` `length`
 function to count the number of attributes associated with a spatial object too.
 
 ```{r shapefile-attributes}
-#just view the attributes & first 6 attribute values of the data
+# just view the attributes & first 6 attribute values of the data
 head(lines_HARV@data)
 
-#how many attributes are in our vector data object?
+# how many attributes are in our vector data object?
 length(lines_HARV@data)
 
 ```
@@ -192,7 +184,7 @@ of attribute values using  `head(lines_HARV@data)`.
 Let's give it a try.
 
 ```{r view-shapefile-attributes }
-#view just the attribute names for the lines_HARV spatial object
+# view just the attribute names for the lines_HARV spatial object
 names(lines_HARV@data)
 
 ```
@@ -210,14 +202,14 @@ spatial objects.
 </div>
 
 ```{r challenge-code-attributes-classes, results="hide", echo=FALSE}
-#1
+# 1
 length(names(point_HARV@data))  #14 attributes
 names(aoiBoundary_HARV@data)  #1 attribute
 
-#2
+# 2
 head(point_HARV@data)  #Harvard University, LTER
 
-#3
+# 3
 point_HARV@data  # C Country
 ```
 
@@ -228,7 +220,7 @@ to exploring values in a column. We can do this using the `$` and the name of
 the attribute: `objectName$attributeName`. 
 
 ```{r explore-attribute-values }
-#view all attributes in the lines shapefile within the TYPE field
+# view all attributes in the lines shapefile within the TYPE field
 lines_HARV$TYPE
 
 ```
@@ -247,11 +239,11 @@ from a spatial object in `R`.
 # "footpath" lines
 lines_HARV[lines_HARV$TYPE == "footpath",]
 
-#save an object with only footpath lines
+# save an object with only footpath lines
 footpath_HARV<-lines_HARV[lines_HARV$TYPE == "footpath",]
 footpath_HARV
 
-#how many features are in our new object
+# how many features are in our new object
 length(footpath_HARV)
 ```
 
@@ -261,7 +253,7 @@ that only two feature lines in our spatial object have the attribute "TYPE=footp
 We can plot our subsetted shapefiles.
 
 ```{r plot-subset-shapefile}
-#plot just footpaths
+# plot just footpaths
 plot(footpath_HARV,
      lwd=6,
      main="Footpaths at NEON Harvard Forest Field Site")
@@ -280,7 +272,7 @@ to our features. We use the syntax:
 to do this.
 
 ```{r plot-subset-shapefile-unique-colors }
-#plot just footpaths
+# plot just footpaths
 plot(footpath_HARV,
      col=c("green","blue"), #set color for each feature 
      lwd=6,
@@ -301,39 +293,38 @@ Subset out all:
 For each plot, color each feature using a unique color.
 </div>
 
-
 ```{r challenge-code-feature-subset, results="hide", echo=FALSE}
 
-
-#save an object with only boardwalk lines
+# save an object with only boardwalk lines
 boardwalk_HARV<-lines_HARV[lines_HARV$TYPE == "boardwalk",]
 boardwalk_HARV
 
-#how many features are in our new object
+# how many features are in our new object
 length(boardwalk_HARV)
 
-#plot just footpaths
+# plot just footpaths
 plot(boardwalk_HARV,
-     col=c("green"), #set color for each feature 
+     col=c("green"), # set color for feature 
      lwd=6,
-     main="Boardwalks at NEON Harvard Forest Field Site\n Feature one = blue, Feature two= green")
+     main="Boardwalks at NEON Harvard Forest Field Site\n 
+		 Feature one = blue, Feature two= green")
 
-
-#save an object with only boardwalk lines
+# save an object with only boardwalk lines
 stoneWall_HARV<-lines_HARV[lines_HARV$TYPE == "stone wall",]
 stoneWall_HARV
 
-#how many features are in our new object
+# how many features are in our new object
 length(stoneWall_HARV)
 
-#plot just footpaths
+# plot just footpaths
 plot(stoneWall_HARV,
-     col=c("green", "blue", "orange", "brown", "springgreen"), #set color for each feature 
+     col=c("green", "blue", "orange", "brown", "springgreen"), #set color 
+		 # for each feature 
      lwd=6,
-     main="Stone walls at NEON Harvard Forest Field Site\n Feature one = blue, Feature two= green")
+     main="Stone walls at NEON Harvard Forest Field Site\n 
+		 Feature one = blue, Feature two= green")
 
 ```
-
 
 ## Plot Lines by Attribute Value
 To plot vector data with the color determined by a set of attribute values, the 
@@ -344,27 +335,26 @@ a determined *order*.
 
 By default, `R` will import spatial object attributes as `factors`.
 
-
 <i class="fa fa-star"></i> **Data Tip:** If our data attribute values are not 
 read in as factors, we can convert the categorical 
 attribute values using `as.factor()`.
 {: .notice}
 
 ```{r convert-to-factor }
-#view the original class of the TYPE column
+# view the original class of the TYPE column
 class(lines_HARV$TYPE)
 
-#view levels or categories - note that there are no categories yet in our data!
-#the attributes are just read as a list of character elements.
+# view levels or categories - note that there are no categories yet in our data!
+# the attributes are just read as a list of character elements.
 levels(lines_HARV$TYPE)
 
-#Convert the TYPE attribute into a factor
-#Only do this IF the data do not import as a factor!
-#lines_HARV$TYPE <- as.factor(lines_HARV$TYPE)
-#class(lines_HARV$TYPE)
-#levels(lines_HARV$TYPE)
+# Convert the TYPE attribute into a factor
+# Only do this IF the data do not import as a factor!
+# lines_HARV$TYPE <- as.factor(lines_HARV$TYPE)
+# class(lines_HARV$TYPE)
+# levels(lines_HARV$TYPE)
 
-#how many features are in each category or level?
+# how many features are in each category or level?
 summary(lines_HARV$TYPE)
 ```
 
@@ -386,24 +376,24 @@ Let's give this a try.
 
 
 ``` {r palette-and-plot}
-#Check the class of the attribute - is it a factor?
+# Check the class of the attribute - is it a factor?
 class(lines_HARV$TYPE)
 
-#how many "levels" or unique values does hte factor have?
-#view factor values
+# how many "levels" or unique values does hte factor have?
+# view factor values
 levels(lines_HARV$TYPE)
-#count the number of unique values or levels
+# count the number of unique values or levels
 length(levels(lines_HARV$TYPE))
 
-#create a color palette of 4 colors - one for each factor level
+# create a color palette of 4 colors - one for each factor level
 roadPalette <- c("blue","green","grey","purple")
 roadPalette
-#create a vector of colors - one for each feature in our vector object
-#according to its attribute value
+# create a vector of colors - one for each feature in our vector object
+# according to its attribute value
 roadColors <- c("blue","green","grey","purple")[lines_HARV$TYPE]
 roadColors
 
-#plot the lines data, apply a diff color to each factor level)
+# plot the lines data, apply a diff color to each factor level)
 plot(lines_HARV, 
      col=roadColors,
      lwd=3,
@@ -415,15 +405,12 @@ plot(lines_HARV,
 We can also adjust the width of our plot lines using `lwd`. We can set all lines
 to be thicker or thinner using `lwd=`. 
 
-     
 ```{r adjust-line-width}
-#make all lines thicker
+# make all lines thicker
 plot(lines_HARV, 
      col=roadColors,
      main="Roads at the NEON Harvard Forest Field Site \n All Lines Thickness=6",
      lwd=6)
-
-
 
 ```     
 
@@ -438,12 +425,11 @@ spatial object attribute of interest like so:
 Note that this requires the attribute to be of class `factor`. Let's give it a 
 try.
 
-
 ```{r line-width-unique }
 class(lines_HARV$TYPE)
 levels(lines_HARV$TYPE)
-#adjust line width by level
-#in this case, boardwalk (the first level) is the widest.
+# adjust line width by level
+# in this case, boardwalk (the first level) is the widest.
 plot(lines_HARV, 
      col=roadColors,
      main="Roads at the NEON Harvard Forest Field Site \n Line width varies by Type Attribute Value",
@@ -468,17 +454,18 @@ Create a plot of roads using the following line thicknesses:
 
 ```{r bicycle-map, include=TRUE, results="hide", echo=FALSE}
 
-#view the factor levels
+# view the factor levels
 levels(lines_HARV$TYPE)
-#create vector of line width values
+# create vector of line width values
 lineWidth <- c(2,4,3,8)[lines_HARV$TYPE]
-#view vector
+# view vector
 lineWidth
 
-#in this case, boardwalk (the first level) is the widest.
+# in this case, boardwalk (the first level) is the widest.
 plot(lines_HARV, 
      col=roadColors,
-     main="Roads at the NEON Harvard Forest Field Site \n Line width varies by Type Attribute Value",
+     main="Roads at the NEON Harvard Forest Field Site \n
+		 Line width varies by Type Attribute Value",
      lwd=lineWidth)
 
 ```
@@ -487,8 +474,6 @@ plot(lines_HARV,
 we can create an vector of numbers, each of which specifies the thickness of each
 feature in our `SpatialLinesDataFrame` by factor level (category): `c(6,4,1,2)[lines_HARV$TYPE]`
 {: .notice}
-
-
 
 ## Add Plot Legend
 We can add a legend to our plot too. When we add a legend, we use the following
@@ -509,13 +494,14 @@ plot(lines_HARV,
      col=roadColors,
      main="Roads at the NEON Harvard Forest Field Site\n Default Legend")
 
-#we can use the color object that we created above to color the legend objects
+# we can use the color object that we created above to color the legend objects
 roadPalette
 
-#add a legend to our map
-legend("bottomright",   #location of legend
-      legend=levels(lines_HARV$TYPE), #categories or elements to render in the legend
-      fill=roadPalette) #color palette to use to fill objects in legend.
+# add a legend to our map
+legend("bottomright",   # location of legend
+      legend=levels(lines_HARV$TYPE), # categories or elements 
+			 # to render in the legend
+      fill=roadPalette) # color palette to use to fill objects in legend.
 
 ```
 
@@ -531,7 +517,7 @@ Let's try it out.
 plot(lines_HARV, 
      col=roadColors,
      main="Roads at the NEON Harvard Forest Field Site \n Modified Legend")
-#add a legend to our map
+# add a legend to our map
 legend("bottomright", 
        legend=levels(lines_HARV$TYPE), 
        fill=roadPalette, 
@@ -549,15 +535,16 @@ Let's try it!
 
 ```{r plot-different-colors}
 
-#manually set the colors for the plot!
+# manually set the colors for the plot!
 newColors <- c("springgreen", "blue", "magenta", "orange")
 newColors
 
-#plot using new colors
+# plot using new colors
 plot(lines_HARV, 
      col=(newColors)[lines_HARV$TYPE],
      main="Roads at the NEON Harvard Forest Field Site \n Pretty Colors")
-#add a legend to our map
+
+# add a legend to our map
 legend("bottomright", 
        levels(lines_HARV$TYPE), 
        fill=newColors, 
@@ -586,37 +573,36 @@ other lines can be grey.
 </div>
 
 ```{r bicycle-map-2, include=TRUE, results="hide", echo=FALSE}
-#view levels 
+# view levels 
 levels(lines_HARV$BicyclesHo)
-#make sure the attribute is of class "Factor"
+# make sure the attribute is of class "Factor"
 
 class(lines_HARV$BicyclesHo)
 
-#convert to factor if necessary
+# convert to factor if necessary
 lines_HARV$BicyclesHo <- as.factor(lines_HARV$BicyclesHo)
 levels(lines_HARV$BicyclesHo)
 
-#remove NA values
+# remove NA values
 lines_removeNA <- lines_HARV[na.omit(lines_HARV$BicyclesHo),]
-#count factor levels
+# count factor levels
 length(levels(lines_HARV$BicyclesHo))
-#set colors so only the allowed roads are magenta
-#note there are 3 levels so we need 3 colors
+# set colors so only the allowed roads are magenta
+# note there are 3 levels so we need 3 colors
 challengeColors <- c("magenta","grey","grey")
 challengeColors
 
-
-#set line width so the first factor level is thicker than the others
+# set line width so the first factor level is thicker than the others
 lines_HARV$BicyclesHo
 c(4,1,1)[lines_HARV$BicyclesHo]
 
-#plot using new colors
+# plot using new colors
 plot(lines_HARV,
      col=(challengeColors)[lines_HARV$BicyclesHo],
      lwd=c(4,1,1)[lines_HARV$BicyclesHo],
      main="Roads Where Bikes and Horses Are Allowed \n NEON Harvard Forest Field Site")
 
-#add a legend to our map
+# add a legend to our map
 legend("bottomright", 
        levels(lines_HARV$BicyclesHo), 
        fill=challengeColors, 
@@ -624,8 +610,6 @@ legend("bottomright",
        cex=.7) #adjust font size
 
 ```
-
-
 
 <div id="challenge" markdown="1">
 ## Challenge 2: Plot Polygon by Attribute
@@ -648,14 +632,12 @@ factor level using the syntax described above for line width:
 </div>
 
 ``` {r challenge-code-plot-color, results="hide", warning= FALSE, echo=FALSE}
-##1
-#Read the shapefile file
+## 1
+# Read the shapefile file
 State.Boundary.US <- readOGR("NEON-DS-Site-Layout-Files/US-Boundary-Layers",
           "US-State-Boundaries-Census-2014")
 
-
-
-#how many levels?
+# how many levels?
 levels(State.Boundary.US$region)
 colors <- c("purple","springgreen","yellow","brown","grey")
 colors
@@ -663,32 +645,33 @@ colors
 plot(State.Boundary.US,
      col=(colors)[State.Boundary.US$region],
      main="Contiguous U.S. State Boundaries \n 50 Colors")
-#add a legend to our map
+
+# add a legend to our map
 legend("bottomright", 
        levels(State.Boundary.US$region), 
        fill=colors, 
        bty="n", #turn off border
        cex=.7) #adjust font size
 
-##2
-#open plot locations
+## 2
+# open plot locations
 plotLocations <- readOGR("NEON-DS-Site-Layout-Files/HARV",
           "PlotLocations_HARV")
 
-#how many unique soils?  Two
+# how many unique soils?  Two
 unique(plotLocations$soilTypeOr)
 
-#create new color palette -- topo.colors palette
+# create new color palette -- topo.colors palette
 blueGreen <- c("blue","springgreen")
 blueGreen
 
-#plot the locations 
+# plot the locations 
 plot(plotLocations,
      col=(blueGreen)[plotLocations$soilTypeOr], 
      pch=18,
      main="NEON Field Sites by Soil Type\n One Symbol for All Types")
 
-#create legend 
+# create legend 
 legend("bottomright", 
        legend=c("Intceptisols","Histosols"),
        pch=18, 
@@ -696,18 +679,18 @@ legend("bottomright",
        bty="n", 
        cex=1)
 
-############ Challenge Part 3 ############
-#create vector of plot symbols
+## 3
+# create vector of plot symbols
 plSymbols <- c(15,17)[plotLocations$soilTypeOr]
 plSymbols
 
-#plot the locations 
+# plot the locations 
 plot(plotLocations,
      col=plotLocations$soilTypeOr, 
      pch=plSymbols,
      main="NEON Field Sites by Soil Type\n Unique Symbol for Each Type")
 
-#create legend 
+# create legend 
 legend("bottomright", 
        legend=c("Intceptisols","Histosols"),
        pch=plSymbols, 

--- a/02-plot-multiple-shapefiles-custom-legend.Rmd
+++ b/02-plot-multiple-shapefiles-custom-legend.Rmd
@@ -62,17 +62,7 @@ preferably RStudio, loaded on your computer.
 
 {% include/_greyBox-wd-rscript.html %}
 
-**Vector Lesson Series:** This lesson is part of a lesson series on 
-[vector data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-vector-series).
-It is also part of a larger 
-[spatio-temporal Data Carpentry Workshop ]({{ site.baseurl }}self-paced-tutorials/spatio-temporal-workshop)
-that includes working with
-[raster data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-raster-series) 
-and [tabular time series in R ]({{ site.baseurl }}self-paced-tutorials/tabular-time-series).
-
 </div>
-
-
 
 ## Load the Data
 To work with vector data in `R`, we can use the `rgdal` library. The `raster` 
@@ -87,23 +77,23 @@ field site. The third is a file containing the Harvard Forest Fisher tower locat
 
 
 ```{r load-packages-data }
-#load packages
-#rgdal: for vector work; sp package should always load with rgdal. 
+# load packages
+# rgdal: for vector work; sp package should always load with rgdal. 
 library(rgdal)  
-#raster: for metadata/attributes- vectors or rasters
+# raster: for metadata/attributes- vectors or rasters
 library (raster)   
 
-#set working directory to data folder
-#setwd("pathToDirHere")
+# set working directory to data folder
+# setwd("pathToDirHere")
 
-#Import a polygon shapefile 
+# Import a polygon shapefile 
 aoiBoundary_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                             "HarClip_UTMZ18")
 
-#Import a line shapefile
+# Import a line shapefile
 lines_HARV <- readOGR( "NEON-DS-Site-Layout-Files/HARV/", "HARV_roads")
 
-#Import a point shapefile 
+# Import a point shapefile 
 point_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                       "HARVtower_UTM18N")
 
@@ -115,37 +105,37 @@ point_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
 In [vector 01 -  to work with 
 shapefile attributes in `R`]({{ site.baseurl }}//R/shapefile-attributes-in-R/) 
 we created a plot where we customized the width of each line in a spatial object
-according to a factor level or category. To do this, we create a vector of colors
-containing a color value for EACH feature in our spatial object grouped by factor 
-level or category.
-
+according to a factor level or category. To do this, we create a vector of
+colors containing a color value for EACH feature in our spatial object grouped
+by factor level or category.
 
 ```{r plot-unique-lines }
 
-#view the factor levels
+# view the factor levels
 levels(lines_HARV$TYPE)
-#create vector of line width values
+# create vector of line width values
 lineWidth <- c(2,4,3,8)[lines_HARV$TYPE]
-#view vector
+# view vector
 lineWidth
 
-#create a color palette of 4 colors - one for each factor level
+# create a color palette of 4 colors - one for each factor level
 roadPalette <- c("blue","green","grey","purple")
 roadPalette
-#create a vector of colors - one for each feature in our vector object
-#according to its attribute value
+# create a vector of colors - one for each feature in our vector object
+# according to its attribute value
 roadColors <- c("blue","green","grey","purple")[lines_HARV$TYPE]
 roadColors
 
-#create vector of line width values
+# create vector of line width values
 lineWidth <- c(2,4,3,8)[lines_HARV$TYPE]
-#view vector
+# view vector
 lineWidth
 
-#in this case, boardwalk (the first level) is the widest.
+# in this case, boardwalk (the first level) is the widest.
 plot(lines_HARV, 
      col=roadColors,
-     main="Roads at the NEON Harvard Forest Field Site \n Line width varies by Type Attribute Value",
+     main="Roads at the NEON Harvard Forest Field Site \n
+		 Line width varies by Type Attribute Value",
      lwd=lineWidth)
 
 ```
@@ -154,8 +144,6 @@ plot(lines_HARV,
 we can create a vector of numbers, each of which specifies the thickness of each
 feature in our `SpatialLinesDataFrame` by factor level (category): `c(6,4,1,2)[lines_HARV$TYPE]`
 {: .notice}
-
-
 
 ## Add Plot Legend
 We also learned how to add a basic legend to our plot.
@@ -175,10 +163,10 @@ plot(lines_HARV,
      col=roadColors,
      main="Roads at the NEON Harvard Forest Field Site\n Default Legend")
 
-#we can use the color object that we created above to color the legend objects
+# we can use the color object that we created above to color the legend objects
 roadPalette
 
-#add a legend to our map
+# add a legend to our map
 legend("bottomright", 
        legend=levels(lines_HARV$TYPE), 
        fill=roadPalette, 
@@ -200,7 +188,7 @@ the tower location and road data on top using `add=TRUE`.
 
 ```{r plot-many-shapefiles }
 
-#Plot multiple shapefiles
+# Plot multiple shapefiles
 plot(aoiBoundary_HARV, 
      col = "grey93", 
      border="grey",
@@ -215,7 +203,7 @@ plot(point_HARV,
      pch = 19, 
      col = "purple")
 
-#assign plot to an object for easy modification!
+# assign plot to an object for easy modification!
 plot_HARV<- recordPlot()
 
 ```
@@ -238,14 +226,14 @@ them. We will start with the labels.
 
 ```{r create-custom-labels }
 
-#create a list of all labels
+# create a list of all labels
 labels <- c("Tower", "AOI", levels(lines_HARV$TYPE))
 labels
 
-#render plot
+# render plot
 plot_HARV
 
-#add a legend to our map
+# add a legend to our map
 legend("bottomright", 
        legend=labels, 
        bty="n", #turn off the legend border
@@ -257,22 +245,22 @@ element next. We can use the vectors of colors that we created earlier to do thi
 
 ```{r add-colors }
 
-#we have a list of colors that we used above - we can use it in the legend
+# we have a list of colors that we used above - we can use it in the legend
 roadPalette
 
-#create a list of colors to use 
+# create a list of colors to use 
 plotColors <- c("purple", "grey", roadPalette)
 plotColors
 
-#render plot
+# render plot
 plot_HARV
 
-#add a legend to our map
+# add a legend to our map
 legend("bottomright", 
        legend=labels, 
        fill=plotColors,
-       bty="n", #turn off the legend border
-       cex=.8) #decrease the font / legend size
+       bty="n", # turn off the legend border
+       cex=.8) # decrease the font / legend size
 
 ```
 
@@ -290,16 +278,16 @@ type `?pch` into the `R` console.
 
 ```{r custom-symbols }
 
-#create a list of pch values
-#these are the symbols that will be used for each legend value
+# create a list of pch values
+# these are the symbols that will be used for each legend value
 # ?pch will provide more information on values
 plotSym <- c(16,15,15,15,15,15)
 plotSym
 
-#Plot multiple shapefiles
+# Plot multiple shapefiles
 plot_HARV
 
-#to create a custom legend, we need to fake it
+# to create a custom legend, we need to fake it
 legend("bottomright", 
        legend=labels,
        pch=plotSym, 
@@ -311,7 +299,7 @@ legend("bottomright",
 
 Now we've added a point symbol to represent our point element in the plot. However
 it might be more useful to use line symbols in our legend
-rather than squares to represent the line data. We can create line symbols, using
+rather than squares to represent the line data. We can create line symbols, 
 using `lty = ()`. We have a total of 6 elements in our legend:
 
 1.   Tower Location
@@ -329,16 +317,16 @@ symbol, but to instead use a line.
 
 
 ```{r refine-legend}
-#Create line object
+# create line object
 lineLegend = c(NA,NA,1,1,1,1)
 lineLegend
 plotSym <- c(16,15,NA,NA,NA,NA)
 plotSym
 
-#Plot multiple shapefiles
+# plot multiple shapefiles
 plot_HARV
 
-#Build a custom legend
+# build a custom legend
 legend("bottomright", 
        legend=labels, 
        lty = lineLegend,
@@ -368,40 +356,40 @@ Create a custom legend.
 </div>
 
 ``` {r challenge-code-plot-color, results="hide", warning= FALSE, echo=FALSE}
-##1
-#open plot locations
+## 1
+# open plot locations
 plotLocations <- readOGR("NEON-DS-Site-Layout-Files/HARV",
           "PlotLocations_HARV")
 
-#how many unique soils?  Two
+# how many unique soils?  Two
 unique(plotLocations$soilTypeOr)
 
-#create new color palette -- topo.colors palette
+# create new color palette -- topo.colors palette
 blueGreen <- c("blue","springgreen")
 blueGreen
 
-#plot roads
+# plot roads
 plot(lines_HARV, 
      col=roadColors,
      main="NEON Field Sites by Soil Type\n One Symbol for All Types")
 
-#plot the locations 
+# plot the locations 
 plot(plotLocations,
      col=(blueGreen)[plotLocations$soilTypeOr], 
      pch=18,
      add=TRUE)
 
-
-#Create line object
+# create line object
 lineLegendElement = c(NA,NA,1,1,1,1)
 lineLegendElement
 plotSymElements <- c(18,18,NA,NA,NA,NA)
 plotSymElements
 
-#create vector of colors
+# create vector of colors
 colorElements <- c(blueGreen, roadPalette)
 colorElements
-#create legend 
+
+# create legend 
 legend("bottomright", 
        legend=c("Intceptisols","Histosols",levels(lines_HARV$TYPE)),
        pch=plotSymElements, 
@@ -410,35 +398,32 @@ legend("bottomright",
        bty="n", 
        cex=1)
 
-
-
-############ Challenge Part 2 ############
-#create vector of plot symbols
+## 2
+# create vector of plot symbols
 plSymbols <- c(15,17)[plotLocations$soilTypeOr]
 plSymbols
 
-#plot roads
+# plot roads
 plot(lines_HARV, 
      col=roadColors,
      main="NEON Field Sites by Soil Type\n One Symbol for All Types")
 
-#plot the locations 
+# plot the locations 
 plot(plotLocations,
      col=(blueGreen)[plotLocations$soilTypeOr], 
      pch=18,
      add=TRUE)
 
-
-#Create line object
+# create line object
 lineLegendElement  <- c(NA,NA,1,1,1,1)
 lineLegendElement
 plotSymElementsMod <- c(15,17,NA,NA,NA,NA)
 plotSymElementsMod
 
-#create vector of colors
+# create vector of colors
 colorElements <- c(blueGreen, roadPalette)
 colorElements
-#create legend 
+# create legend 
 legend("bottomright", 
        legend=c("Intceptisols","Histosols",levels(lines_HARV$TYPE)),
        pch=plotSymElementsMod, 

--- a/03-when-vector-data-dont-line-up-CRS.Rmd
+++ b/03-when-vector-data-dont-line-up-CRS.Rmd
@@ -69,17 +69,8 @@ preferably RStudio, loaded on your computer.
 
 {% include/_greyBox-wd-rscript.html %}
 
-**Vector Lesson Series:** This lesson is part of a lesson series on 
-[vector data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-vector-series).
-It is also part of a larger 
-[spatio-temporal Data Carpentry Workshop ]({{ site.baseurl }}self-paced-tutorials/spatio-temporal-workshop)
-that includes working with
-[raster data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-raster-series) 
-and [tabular time series in R ]({{ site.baseurl }}self-paced-tutorials/tabular-time-series).
-
 </div>
 
- 
 ## Working With Spatial Data From Different Sources
 
 To support a project, we often need to gather spatial datasets for from 
@@ -114,8 +105,6 @@ seems proportionally larger or smaller than they actually are!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/KUF_Ckv8HbE" frameborder="0" allowfullscreen></iframe>
 
-
-
 In this tutorial we will learn how to identify and manage spatial data 
 in different projections. We will learn how to `reproject` the data so that they
 are in the same projection to support plotting / mapping. Note that these skills
@@ -126,12 +115,12 @@ We will use the `rgdal` and `raster` libraries in this tutorial.
 
 ```{r load-libraries}
 
-#load packages
-library(rgdal)  #for vector work; sp package should always load with rgdal. 
-library (raster)   #for metadata/attributes- vectors or rasters
+# load packages
+library(rgdal)  # for vector work; sp package should always load with rgdal. 
+library (raster)   # for metadata/attributes- vectors or rasters
 
-#set working directory to data folder
-#setwd("pathToDirHere")
+# set working directory to data folder
+# setwd("pathToDirHere")
 
 ```
 
@@ -157,11 +146,11 @@ from the Census website to support the learning goals of this tutorial.
 
 ```{r read-csv }
 
-#Read the .csv file
+# Read the .csv file
 State.Boundary.US <- readOGR("NEON-DS-Site-Layout-Files/US-Boundary-Layers",
           "US-State-Boundaries-Census-2014")
 
-#look at the data structure
+# look at the data structure
 class(State.Boundary.US)
 
 ```
@@ -175,7 +164,7 @@ Next, let's plot the U.S. states data.
 
 ```{r find-coordinates }
 
-#view column names
+# view column names
 plot(State.Boundary.US, 
      main="Map of Continental US State Boundaries\n US Census Bureau Data")
 
@@ -190,19 +179,19 @@ If we specify a thicker line width using `lwd=4` for the border layer, it will
 make our map pop!
 
 ```{r check-out-coordinates }
-#Read the .csv file
+# Read the .csv file
 Country.Boundary.US <- readOGR("NEON-DS-Site-Layout-Files/US-Boundary-Layers",
           "US-Boundary-Dissolved-States")
 
-#look at the data structure
+# look at the data structure
 class(Country.Boundary.US)
 
-#view column names
+# view column names
 plot(State.Boundary.US, 
      main="Map of Continental US State Boundaries\n US Census Bureau Data",
      border="gray40")
 
-#view column names
+# view column names
 plot(Country.Boundary.US, 
      lwd=4, 
      border="gray18",
@@ -216,12 +205,12 @@ As we are adding these layers, take note of the class of each object.
 
 ```{r explore-units}
 
-#Import a point shapefile 
+# Import a point shapefile 
 point_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                       "HARVtower_UTM18N")
 class(point_HARV)
 
-#plot point - looks ok? 
+# plot point - looks ok? 
 plot(point_HARV, 
      pch = 19, 
      col = "purple",
@@ -233,18 +222,18 @@ will plot! Let's next add it as a layer on top of the U.S. states and boundary
 layers in our basemap plot.
 
 ``` {r layer-point-on-states }
-#plot state boundaries  
+# plot state boundaries  
 plot(State.Boundary.US, 
      main="Map of Continental US State Boundaries \n with Tower Location",
      border="gray40")
 
-#Add US border outline 
+# add US border outline 
 plot(Country.Boundary.US, 
      lwd=4, 
      border="gray18",
      add=TRUE)
 
-#add point tower location
+# add point tower location
 plot(point_HARV, 
      pch = 19, 
      col = "purple",
@@ -261,10 +250,10 @@ U.S. boundary layers.
 
 ```{r crs-sleuthing} 
 
-#view CRS of our site data
+# view CRS of our site data
 crs(point_HARV)
 
-#view crs of census data
+# view crs of census data
 crs(State.Boundary.US)
 crs(Country.Boundary.US)
 ```
@@ -326,12 +315,11 @@ object compared to the `State.Boundary.US` object.
 
 ```{r view-extent }
 
-#extent for HARV in UTM
+# extent for HARV in UTM
 extent(point_HARV)
 
-#extent for object in geographic
+# extent for object in geographic
 extent(State.Boundary.US)
-
 
 ```
 
@@ -377,13 +365,13 @@ longitude `WGS84` coordinate reference system (CRS).
 
 ```{r crs-sptranform } 
 
-#reproject data
+# reproject data
 point_HARV_WGS84 <- spTransform(point_HARV,
                                 crs(State.Boundary.US))
 
-#what is the CRS of the new object
+# what is the CRS of the new object
 crs(point_HARV_WGS84)
-#does the extent look like decimal degrees?
+# does the extent look like decimal degrees?
 extent(point_HARV_WGS84)
 ```
 
@@ -391,18 +379,18 @@ Once our data are reprojected, we can try to plot again.
 
 ```{r plot-again }
 
-#plot state boundaries  
+# plot state boundaries  
 plot(State.Boundary.US, 
      main="Map of Continental US State Boundaries\n With Fisher Tower Location",
      border="gray40")
 
-#Add US border outline 
+# add US border outline 
 plot(Country.Boundary.US, 
      lwd=4, 
      border="gray18",
      add=TRUE)
 
-#add point tower location
+# add point tower location
 plot(point_HARV_WGS84, 
      pch = 19, 
      col = "purple",
@@ -430,36 +418,36 @@ the Tower location point.
 </div>
 
 ```{r challenge-code-MASS-Map,  include=TRUE, results="hide", echo=FALSE, warning=FALSE}
-#import mass boundary layer
-#Read the .csv file
+# import mass boundary layer
+# read the .csv file
 NE.States.Boundary.US <- readOGR("NEON-DS-Site-Layout-Files/US-Boundary-Layers",
           "Boundary-US-State-NEast")
-#view crs
+# view crs
 crs(NE.States.Boundary.US)
 
-#create CRS object
+# create CRS object
 UTM_CRS <- crs(point_HARV)
 UTM_CRS
 
-#reproject line and point data
+# reproject line and point data
 NE.States.Boundary.US.UTM  <- spTransform(NE.States.Boundary.US,
                                 UTM_CRS)
 NE.States.Boundary.US.UTM
 
-#plot state boundaries  
+# plot state boundaries  
 plot(NE.States.Boundary.US.UTM , 
      main="Map of Northeastern US\n With Fisher Tower Location - UTM Zone 18N",
      border="gray18",
      lwd=2)
 
-#add point tower location
+# add point tower location
 plot(point_HARV, 
      pch = 19, 
      col = "purple",
      add=TRUE)
 
-#add legend
-#to create a custom legend, we need to fake it
+# add legend
+# to create a custom legend, we need to fake it
 legend("bottomright", 
        legend=c("State Boundary","Fisher Tower"),
        lty=c(1,NA),

--- a/04-csv-vector-raster-plotting.Rmd
+++ b/04-csv-vector-raster-plotting.Rmd
@@ -69,14 +69,6 @@ preferably RStudio, loaded on your computer.
 
 {% include/_greyBox-wd-rscript.html %}
 
-**Vector Lesson Series:** This lesson is part of a lesson series on 
-[vector data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-vector-series).
-It is also part of a larger 
-[spatio-temporal Data Carpentry Workshop ]({{ site.baseurl }}self-paced-tutorials/spatio-temporal-workshop)
-that includes working with
-[raster data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-raster-series) 
-and [tabular time series in R ]({{ site.baseurl }}self-paced-tutorials/tabular-time-series).
-
 </div>
 
 ## Spatial Data in Text Format
@@ -107,15 +99,14 @@ We will use the `rgdal` and `raster` libraries in this tutorial.
 
 ```{r load-libraries}
 
-#load packages
-library(rgdal)  #for vector work; sp package should always load with rgdal. 
-library (raster)   #for metadata/attributes- vectors or rasters
+# load packages
+library(rgdal)  # for vector work; sp package should always load with rgdal. 
+library (raster)   # for metadata/attributes- vectors or rasters
 
-#set working directory to data folder
-#setwd("pathToDirHere")
+# set working directory to data folder
+# setwd("pathToDirHere")
 
 ```
-
 
 ## Import .csv 
 To begin let's import `.csv` file that contains plot coordinate `x, y`
@@ -125,12 +116,12 @@ rather than a `factor` class.
 
 ```{r read-csv }
 
-#Read the .csv file
+# Read the .csv file
 plot.locations_HARV <- 
   read.csv("NEON-DS-Site-Layout-Files/HARV/HARV_PlotLocations.csv",
            stringsAsFactors = FALSE)
 
-#look at the data structure
+# look at the data structure
 str(plot.locations_HARV)
 
 ```
@@ -149,7 +140,7 @@ Let's check out the column `names` of our file.
 
 ```{r find-coordinates }
 
-#view column names
+# view column names
 names(plot.locations_HARV)
 
 ```
@@ -161,12 +152,12 @@ fields that might contain spatial information. The `plot.locations_HARV$easting`
 and `plot.locations_HARV$northing` columns contain coordinate values. 
 
 ```{r check-out-coordinates }
-#view first 6 rows of the X and Y columns
+# view first 6 rows of the X and Y columns
 head(plot.locations_HARV$easting)
 head(plot.locations_HARV$northing)
 
-#Note that  you can also call the same two columns using their COLUMN NUMBER
-#view first 6 rows of the X and Y columns
+# note that  you can also call the same two columns using their COLUMN NUMBER
+# view first 6 rows of the X and Y columns
 head(plot.locations_HARV[,1])
 head(plot.locations_HARV[,2])
 
@@ -182,7 +173,7 @@ There are several ways to figure out the `CRS` of spatial data in text format.
 data. For more information on metadata, check out the
 [Understanding Time Series Metadata]({{site.baseurl}}/R/Time-Series-Metadata) 
 lesson. 
-2. We can explore the file itself to see if `CRS` information is embedded in the 
+2. We can explore the file itself to see if `CRS` information is embedded in the
 file header or somewhere in the data columns.
 
 Following the `easting` and `northing` columns, there is a `geodeticDa` and a 
@@ -191,40 +182,43 @@ Following the `easting` and `northing` columns, there is a `geodeticDa` and a
 
 
 ```{r view-CRS-info }
-#view first 6 rows of the X and Y columns
+# view first 6 rows of the X and Y columns
 head(plot.locations_HARV$geodeticDa)
 head(plot.locations_HARV$utmZone)
 
 ```
 
 It is not typical to store `CRS` information in a column. But this particular
-file contains `CRS` information this way. The `geodeticDa` and `utmZone` columns 
+file contains `CRS` information this way. The `geodeticDa` and `utmZone` columns
 contain the information that helps us determine the `CRS`: 
 
 * `geodeticDa`: WGS84  -- this is geodetic datum WGS84
 * `utmZone`: 18
 
 In 
-[Lesson 02: When Vector Data Don't Line Up - Handling Spatial Projection & CRS in R ]({{site.baseurl}}/R/vector-data-reproject-crs-R/)
+[Vector 02: When Vector Data Don't Line Up - Handling Spatial Projection & CRS in R ]({{site.baseurl}}/R/vector-data-reproject-crs-R/)
 we learned about the components of a `proj4` string. We have everything we need 
 to now assign a `CRS` to our data.frame.
 
 To create the `proj4` associated with `UTM Zone 18 WGS84` we could look up the 
-projection on the <a href="http://www.spatialreference.org/ref/epsg/wgs-84-utm-zone-18n/" target="_blank"> spatial reference website</a> which contains a list of `CRS`
-formats for each projection  - <a href="http://www.spatialreference.org/ref/epsg/wgs-84-utm-zone-18n/proj4/" target="_blank"> click here for the proj4 string for UTM Zone 18N WGS84</a>. 
-However, if we have other data in the `UTM Zone 18N` projection, it's much easier 
-to simply assign the `CRS` in `proj4` format from that object to our new spatial
-object. Let's import the roads layer from Harvard forest and check out its `CRS`.
+projection on the 
+<a href="http://www.spatialreference.org/ref/epsg/wgs-84-utm-zone-18n/" target="_blank"> spatial reference website</a> 
+which contains a list of `CRS` formats for each projection - 
+<a href="http://www.spatialreference.org/ref/epsg/wgs-84-utm-zone-18n/proj4/" target="_blank"> click here for the proj4 string for UTM Zone 18N WGS84</a>. 
+However, if we have other data in the `UTM Zone 18N` projection, it's much
+easier to simply assign the `CRS` in `proj4` format from that object to our new
+spatial object. Let's import the roads layer from Harvard forest and check out
+its `CRS`.
 
 ```{r explore-units}
 
-#Import the line shapefile
+# Import the line shapefile
 lines_HARV <- readOGR( "NEON-DS-Site-Layout-Files/HARV/", "HARV_roads")
 
-#view CRS
+# view CRS
 crs(lines_HARV)
 
-#view extent
+# view extent
 extent(lines_HARV)
 
 ```
@@ -237,7 +231,7 @@ Next, let's create a `crs` object that we can use to define the `CRS` of our
 `SpatialPointsDataFrame` when we create it
 
 ```{r crs-object } 
-#create crs object
+# create crs object
 utm18nCRS <- crs(lines_HARV)
 utm18nCRS
 
@@ -245,8 +239,8 @@ class(utm18nCRS)
 ```
 
 ## .csv to R SpatialPointsDataFrame
-Next, let's convert our `data.frame` into a `SpatialPointsDataFrame`. To do this,
-we need to specify:
+Next, let's convert our `data.frame` into a `SpatialPointsDataFrame`. To do
+this, we need to specify:
 
 1. The columns containing X (`easting`) and Y (`northing`) coordinate values
 2. The CRS that the column coordinate represent (units are included in the CRS) -
@@ -257,12 +251,12 @@ as attributes to your spatial object
 We will use the `SpatialPointsDataFrame()` function to perform the conversion.
 
 ```{r convert-csv-shapefile}
-#note that the easting and northing columns are in columns 1 and 2
+# note that the easting and northing columns are in columns 1 and 2
 plot.locationsSp_HARV <- SpatialPointsDataFrame(plot.locations_HARV[,1:2],
                     plot.locations_HARV,    #the R object to convert
                     proj4string = utm18nCRS)   # assign a CRS 
                                           
-#look at CRS
+# look at CRS
 crs(plot.locationsSp_HARV)
 
 ```
@@ -271,6 +265,7 @@ crs(plot.locationsSp_HARV)
 We now have a spatial `R` object, we can plot our newly created spatial object.
 
 ```{r plot-data-points }
+# plot spatial object
 plot(plot.locationsSp_HARV, 
      main="Map of Plot Locations")
 
@@ -279,7 +274,7 @@ plot(plot.locationsSp_HARV,
 ## Define Plot Extent
 
 In 
-[Lesson 00: Open and Plot Shapefiles in R]({{site.baseurl}}/R/open-shapefiles-in-R/)
+[Vector 00: Open and Plot Shapefiles in R]({{site.baseurl}}/R/open-shapefiles-in-R/)
 we learned about spatial object `extent`. When we plot several spatial layers in
 `R`, the first layer that is plotted, becomes the extent of the plot. If we add
 additional layers that are outside of that extent, then the data will not be
@@ -290,8 +285,9 @@ Let's first create a SpatialPolygon object from the
 `NEON-DS-Site-Layout-Files/HarClip_UTMZ18` shapefile. (If you have completed
 Lesson 00 or 01 in this series you can skip this code as you have already
 created this object.)
+
 ``` {r create-aoi-boundary}
-#Create boundary object 
+# create boundary object 
 aoiBoundary_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                             "HarClip_UTMZ18")
 ```
@@ -299,13 +295,16 @@ aoiBoundary_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
 To begin, let's plot our `aoiBoundary` object with our vegetation plots.
 
 ```{r plot-data }
-
+# plot Boundary
 plot(aoiBoundary_HARV,
      main="AOI Boundary\nNEON Harvard Forest Field Site")
 
+# add plot locations
 plot(plot.locationsSp_HARV, 
      pch=8, add=TRUE)
 
+# no plots added, why? CRS?
+# view CRS of each
 crs(aoiBoundary_HARV)
 crs(plot.locationsSp_HARV)
 
@@ -316,18 +315,20 @@ locations are not rendered. We can see that our data are in the same projection
 - so what is going on?
 
 ```{r compare-extents}
+# view extent of each
 extent(aoiBoundary_HARV)
 extent(plot.locationsSp_HARV)
 
-# Add extra space to right of plot area; 
-#par(mar=c(5.1, 4.1, 4.1, 8.1), xpd=TRUE)
+# add extra space to right of plot area; 
+# par(mar=c(5.1, 4.1, 4.1, 8.1), xpd=TRUE)
 
 plot(extent(plot.locationsSp_HARV),
      col="purple", 
      xlab="easting",
      ylab="northing", lwd=8,
-     main="Extent Boundary of Plot Locations \nCompared to the AOI Spatial Object",
-     ylim=c(4712400,4714000)) #extent the y axis to make room for the legend
+     main="Extent Boundary of Plot Locations \nCompared to the AOI Spatial
+		 Object",
+     ylim=c(4712400,4714000)) # extent the y axis to make room for the legend
 
 plot(extent(aoiBoundary_HARV), 
      add=TRUE,
@@ -367,13 +368,13 @@ values from the spatial object that has a larger extent. Let's try it.
 
 plotLoc.extent <- extent(plot.locationsSp_HARV)
 plotLoc.extent
-#grab the x and y min and max values from the spatial plot locations layer
+# grab the x and y min and max values from the spatial plot locations layer
 xmin <- plotLoc.extent@xmin
 xmax <- plotLoc.extent@xmax
 ymin <- plotLoc.extent@ymin
 ymax <- plotLoc.extent@ymax
 
-#adjust the plot extent using x and ylim
+# adjust the plot extent using x and ylim
 plot(aoiBoundary_HARV,
      main="NEON Harvard Forest Field Site\nModified Extent",
      border="darkgreen",
@@ -383,7 +384,7 @@ plot(aoiBoundary_HARV,
 plot(plot.locationsSp_HARV, 
      pch=8, add=TRUE)
 
-#add a legend
+# add a legend
 legend("bottomright", 
        legend=c("Plots", "AOI Boundary"),
        pch=c(8,NA),
@@ -411,93 +412,94 @@ the X and Y limits of your plot to ensure that both points are rendered by `R`!
 If you have extra time, feel free to add roads and other layers to your map!
 
 HINT: Refer to
-[Lesson 02: When Vector Data Don't Line Up - Handling Spatial Projection & CRS in R]({{site.baseurl}}/R/vector-data-reproject-crs-R/)
+[Vector 02: When Vector Data Don't Line Up - Handling Spatial Projection & CRS in R]({{site.baseurl}}/R/vector-data-reproject-crs-R/)
 for more on working with geographic coordinate systems. You may want to "borrow"
 the projection from the objects used in that lesson!
 </div>
 
 ```{r challenge-code-phen-plots, echo=FALSE, results="hide", warning=FALSE }
-##1
-#Read the .csv file
+## 1
+# Read the .csv file
 newPlot.locations_HARV <- 
   read.csv("NEON-DS-Site-Layout-Files/HARV/HARV_2NewPhenPlots.csv",
            stringsAsFactors = FALSE)
 
-#look at the data structure -> locations in lat/long
+# look at the data structure -> locations in lat/long
 str(newPlot.locations_HARV)
 
-##2
-##Find/ establish a CRS for new points
-#Import the US boundary which is in a geographic WGS84 coordinate system
+## 2
+## Find/ establish a CRS for new points
+# Import the US boundary which is in a geographic WGS84 coordinate system
 Country.Boundary.US <- readOGR("NEON-DS-Site-Layout-Files/US-Boundary-Layers",
           "US-Boundary-Dissolved-States")
 
-#grab the geographic CRS
+# grab the geographic CRS
 geogCRS <- crs(Country.Boundary.US)
 geogCRS
 
-##Convert to spatial data frame
-#note that the easting and northing columns are in columns 1 and 2
+## Convert to spatial data frame
+# note that the easting and northing columns are in columns 1 and 2
 newPlot.Sp.HARV <- SpatialPointsDataFrame(newPlot.locations_HARV[,2:1],
-                    newPlot.locations_HARV,    #the R object to convert
+                    newPlot.locations_HARV,    # the R object to convert
                     proj4string = geogCRS)   # assign a CRS 
                                          
-#look at CRS
+# view CRS
 crs(newPlot.Sp.HARV)
 
-## We now have the data imported and in WGS84 Lat/Long. We want to map with plot locations in 
-##UTM so we'll have to reproject. 
+## We now have the data imported and in WGS84 Lat/Long. We want to map with plot
+# locations in UTM so we'll have to reproject. 
 
-#remember we have a UTM Zone 18N crs object from previous code
+# remember we have a UTM Zone 18N crs object from previous code
 utm18nCRS
 
-#reproject the new points into UTM using `utm18nCRS`
+# reproject the new points into UTM using `utm18nCRS`
 newPlot.Sp.HARV.UTM <- spTransform(newPlot.Sp.HARV,
                                   utm18nCRS)
-#check new plot CRS
+# check new plot CRS
 crs(newPlot.Sp.HARV.UTM)
 
-
-###3
-#create plot
+## 3
+# create plot
 plot(plot.locationsSp_HARV, 
      main="NEON Harvard Forest Field Site \nPlot Locations" )
 
 plot(newPlot.Sp.HARV.UTM, 
      add=TRUE, pch=20, col="darkgreen")
 
-#oops - looks like we are missing a point on our new plot. let's compare
-#the spatial extents of both objects!
+# oops - looks like we are missing a point on our new plot. let's compare
+# the spatial extents of both objects!
 extent(plot.locationsSp_HARV)
 extent(newPlot.Sp.HARV.UTM)
 
-#when you plot in base plot, if the extent isn't specified, then the data that
-#is added FIRST will define the extent of the plot
+# when you plot in base plot, if the extent isn't specified, then the data that
+# is added FIRST will define the extent of the plot
 plot(extent(plot.locationsSp_HARV),
-     main="Comparison of Spatial Object Extents\nPlot Locations vs New Plot Locations")
+     main="Comparison of Spatial Object Extents\n
+		 	Plot Locations vs New Plot Locations")
 plot(extent(newPlot.Sp.HARV.UTM),
      col="darkgreen",
      add=TRUE)
 
-#looks like the green box showing the newPlot extent extends
-#beyond the plot.locations extent.
+# looks like the green box showing the newPlot extent extends
+# beyond the plot.locations extent.
 
-#We need to grab the x min and max and y min from our original plots
-#but then the ymax from our new plots
+# We need to grab the x min and max and y min from our original plots
+# but then the ymax from our new plots
 
 originalPlotExtent <- extent(plot.locationsSp_HARV)
 newPlotExtent <- extent(newPlot.Sp.HARV.UTM)
 
-#set xmin and max
+# set xmin and max
 xmin <- originalPlotExtent@xmin
 xmax <- originalPlotExtent@xmax
 ymin <- originalPlotExtent@ymin
 ymax <- newPlotExtent@ymax
 
-#3 again... re-plot
-#try again but this time specify the x and ylims
-#note: we could also write a function that would harvest the smallest and largest
-#x and y values from an extent object. This is beyond the scope of this lesson.
+# 3 again... re-plot
+# try again but this time specify the x and ylims
+# note: we could also write a function that would harvest the smallest and
+# largest
+# x and y values from an extent object. This is beyond the scope of this lesson.
 plot(plot.locationsSp_HARV, 
      main="NEON Harvard Forest Field Site\nVegetation & Phenology Plots",
      pch=8,
@@ -532,7 +534,7 @@ in `rgdal`. To do this we need the following arguments:
 We can now export the spatial object as a shapefile. 
 
 ``` {r write-shapefile, warnings="hide", eval=FALSE}
-#write a shapefile
+# write a shapefile
 writeOGR(plot.locationsSp_HARV, getwd(),
          "PlotLocations_HARV", driver="ESRI Shapefile")
 

--- a/05-vector-raster-integration-advanced.Rmd
+++ b/05-vector-raster-integration-advanced.Rmd
@@ -54,7 +54,6 @@ preferably RStudio, loaded on your computer.
 
 * [More on Packages in R - Adapted from Software Carpentry.]({{site.baseurl}}R/Packages-In-R/)
 
-
 ### Download Data
 {% include/dataSubsets/_data_Site-Layout-Files.html %}
 {% include/dataSubsets/_data_Airborne-Remote-Sensing.html %}
@@ -63,15 +62,6 @@ preferably RStudio, loaded on your computer.
 
 {% include/_greyBox-wd-rscript.html %}
 
-**Vector Lesson Series:** This lesson is part of a lesson series on 
-[vector data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-vector-series). It is also
-part of a larger 
-[spatio-temporal Data Carpentry Workshop ]({{ site.baseurl }}self-paced-tutorials/spatio-temporal-workshop)
-that includes working with
-[raster data in R ]({{ site.baseurl }}self-paced-tutorials/spatial-raster-series) 
-and  
-[tabular time series in R ]({{ site.baseurl }}self-paced-tutorials/tabular-time-series).
-</div> 
 
 ## Crop a Raster to Vector Extent
 We often work with spatial layers that have different spatial extents.
@@ -81,8 +71,8 @@ We often work with spatial layers that have different spatial extents.
     <img src="{{ site.baseurl }}/images/dc-spatial-vector/spatial_extent.png"></a>
     <figcaption>The spatial extent of a shapefile or R spatial object represents
     the geographic "edge" or location that is the furthest north, south east and 
-    west. Thus is represents the overall geographic coverage of the spatial object. 
-    Image Source: National Ecological Observatory Network (NEON) 
+    west. Thus is represents the overall geographic coverage of the spatial 
+    object. Image Source: National Ecological Observatory Network (NEON) 
     </figcaption>
 </figure>
 
@@ -98,19 +88,19 @@ and a raster file, that we will introduce this lesson:
 * A canopy height model (CHM) in GeoTIFF format -- green
 
 ```{r view-extents, echo=FALSE, results='hide'}
-##Load Packages
-library(rgdal)  #for vector work; sp package should always load with rgdal. 
+## Load Packages
+library(rgdal)  # for vector work; sp package should always load with rgdal. 
 library (raster)
 
-#Import a polygon shapefile 
+# Import a polygon shapefile 
 aoiBoundary_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                             "HarClip_UTMZ18")
 
-#Import a line shapefile
+# Import a line shapefile
 lines_HARV <- readOGR( "NEON-DS-Site-Layout-Files/HARV/", 
                        "HARV_roads")
 
-#Import a point shapefile 
+# Import a point shapefile 
 point_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                       "HARVtower_UTM18N")
 
@@ -118,24 +108,23 @@ chm_HARV <- raster("NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif")
 
 utm18nCRS <- crs(point_HARV)
 
-#Read the .csv file
+# Read the .csv file
 plot.locations_HARV <- 
   read.csv("NEON-DS-Site-Layout-Files/HARV/HARV_PlotLocations.csv",
            stringsAsFactors = FALSE)
 
-#note that the easting and northing columns are in columns 1 and 2
+# note that the easting and northing columns are in columns 1 and 2
 plot.locationsSp_HARV <- SpatialPointsDataFrame(plot.locations_HARV[,1:2],
-                    plot.locations_HARV,    #the R object to convert
+                    plot.locations_HARV,    # the R object to convert
                     proj4string = utm18nCRS)   # assign a CRS 
-
 
 plot(extent(lines_HARV),
      col="purple", lwd="3",
      xlab="Easting", ylab="Northing",
     main="Extent Boundary of Several Spatial Files",
     xlim=c(730741.2,735000),
-    col.lab = 'grey', #set axis label color
-    col.axis = 'grey') #set axis tick label color
+    col.lab = 'grey', # set axis label color
+    col.axis = 'grey') # set axis tick label color
 
 plot(extent(plot.locationsSp_HARV),
      col="black",
@@ -158,11 +147,10 @@ legend("topright",
        bty = "n",  
        cex = .8)
 
-
 ```
 
 ```{r reset-par, results="hide", echo=FALSE }
-#reset par
+# reset par
 dev.off()
 ```
 
@@ -189,26 +177,26 @@ and
 you may already have these `R` spatial objects. 
 
 ```{r load-libraries-data }
-#load necessary packages
-library(rgdal)  #for vector work; sp package should always load with rgdal. 
+# load necessary packages
+library(rgdal)  # for vector work; sp package should always load with rgdal. 
 library (raster)
 
-#set working directory to data folder
-#setwd("pathToDirHere")
+# set working directory to data folder
+# setwd("pathToDirHere")
 
-#Imported in L00: Vector Data in R - Open & Plot Data
+# Imported in Vector 00: Vector Data in R - Open & Plot Data
 # shapefile 
 aoiBoundary_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                             "HarClip_UTMZ18")
-#Import a line shapefile
+# Import a line shapefile
 lines_HARV <- readOGR( "NEON-DS-Site-Layout-Files/HARV/",
                        "HARV_roads")
-#Import a point shapefile 
+# Import a point shapefile 
 point_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                       "HARVtower_UTM18N")
 
-#Imported in L02: .csv to Shapefile in R
-#import raster Canopy Height Model (CHM)
+# Imported in  Vector 02: .csv to Shapefile in R
+# import raster Canopy Height Model (CHM)
 chm_HARV <- 
   raster("NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif")
 
@@ -221,14 +209,14 @@ object that will be used to crop the raster. `R` will use the `extent` of the
 spatial object as the cropping boundary.
 
 ```{r Crop-by-vector-extent}
-#plot full CHM
+# plot full CHM
 plot(chm_HARV,
      main="LiDAR CHM - Not Cropped\nNEON Harvard Forest Field Site")
 
-#crop the chm
+# crop the chm
 chm_HARV_Crop <- crop(x = chm_HARV, y = aoiBoundary_HARV)
 
-#plot full CHM
+# plot full CHM
 plot(extent(chm_HARV),
      lwd=4,col="springgreen",
      main="LiDAR CHM - Cropped\nNEON Harvard Forest Field Site",
@@ -245,7 +233,7 @@ same extent as the `aoiBoundary_HARV` object that was used as a crop extent
 (blue boarder below).
 
 ```{r view-crop-extent, echo=FALSE}
-#view the data in a plot
+# view the data in a plot
 plot(aoiBoundary_HARV, lwd=8, border="blue",
      main = "Cropped LiDAR Canopy Height Model \n NEON Harvard Forest Field Site")
 
@@ -255,7 +243,7 @@ plot(chm_HARV_Crop, add = TRUE)
 We can look at the extent of all the other objects. 
 
 ``` {r view-extent}
-#lets look at the extent of all of our objects
+# lets look at the extent of all of our objects
 extent(chm_HARV)
 extent(chm_HARV_Crop)
 extent(aoiBoundary_HARV)
@@ -282,11 +270,11 @@ you have these plot locations as the spatial `R` spatial object
 
 ```{r challenge-code-crop-raster-points, include=TRUE, results="hide", echo=FALSE}
 
-#Created/imported in L02: .csv to Shapefile in R
+# Created/imported in L02: .csv to Shapefile in R
 plot.locationSp_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
 																"PlotLocations_HARV")
 
-#crop the chm 
+# crop the chm 
 CHM_plots_HARVcrop <- crop(x = chm_HARV, y = plot.locationsSp_HARV)
 
 plot(CHM_plots_HARVcrop,
@@ -337,7 +325,7 @@ We can also use an `extent()` method to define an extent to be used as a croppin
 boundary. This creates an object of class `extent`.
 
 ```{r hidden-extent-chunk}
-#extent format (xmin,xmax,ymin,ymax)
+# extent format (xmin,xmax,ymin,ymax)
 new.extent <- extent(732161.2, 732238.7, 4713249, 4713333)
 class(new.extent)
 ```
@@ -347,10 +335,10 @@ raster.
 
 ```{r crop-using-drawn-extent}
 
-#crop raster
+# crop raster
 CHM_HARV_manualCrop <- crop(x = chm_HARV, y = new.extent)
 
-#plot extent boundary and newly cropped raster
+# plot extent boundary and newly cropped raster
 plot(aoiBoundary_HARV, 
      main = "Manually Cropped Raster\n NEON Harvard Forest Field Site")
 plot(new.extent, col="brown", lwd=4,add = TRUE)
@@ -369,7 +357,6 @@ to create an `extent` object.
 * More on the 
 <a href="http://www.inside-r.org/packages/cran/raster/docs/extent" target="_blank">
 extent class in `R`</a>.
-
 
 ##Extract Raster Pixels Values Using Vector Polygons
 Often we want to extract values from a raster layer for particular locations - 
@@ -400,13 +387,13 @@ Forest field site.
 
 ```{r extract-from-raster}
 
-#extract tree height for AOI
-#set df=TRUE to return a data.frame rather than a list of values
+# extract tree height for AOI
+# set df=TRUE to return a data.frame rather than a list of values
 tree_height <- extract(x = chm_HARV, 
                        y = aoiBoundary_HARV, 
                        df=TRUE)
 
-#view the object
+# view the object
 head(tree_height)
 
 nrow(tree_height)
@@ -428,13 +415,13 @@ height values. These values help us better understand vegetation at our field
 site.
 
 ```{r view-extract-histogram}
-#view histogram of tree heights in study area
+# view histogram of tree heights in study area
 hist(tree_height$HARV_chmCrop, 
      main="Histogram of CHM Height Values (m) \nNEON Harvard Forest Field Site",
      col="springgreen",
      xlab="Tree Height", ylab="Frequency of Pixels")
 
-#view summary of values
+# view summary of values
 summary(tree_height$HARV_chmCrop)
 
 ```
@@ -449,14 +436,14 @@ of summary statistic we are interested in using the `fun=` method. Let's extract
 a mean height value for our AOI. 
 
 ```{r summarize-extract }
-#extract the average tree height (calculated using the raster pixels)
-#located within the AOI polygon
+# extract the average tree height (calculated using the raster pixels)
+# located within the AOI polygon
 av_tree_height_AOI <- extract(x = chm_HARV, 
                               y = aoiBoundary_HARV,
                               fun=mean, 
                               df=TRUE)
 
-#view output
+# view output
 av_tree_height_AOI
 
 ```
@@ -486,22 +473,22 @@ Let's put this into practice by figuring out the average tree height in the
 20m around the tower location. 
 
 ```{r extract-point-to-buffer }
-#what are the units of our buffer
+# what are the units of our buffer
 crs(point_HARV)
 
-#extract the average tree height (height is given by the raster pixel value)
-#at the tower location
-#use a buffer of 20 meters and mean function (fun) 
+# extract the average tree height (height is given by the raster pixel value)
+# at the tower location
+# use a buffer of 20 meters and mean function (fun) 
 av_tree_height_tower <- extract(x = chm_HARV, 
                                 y = point_HARV, 
                                 buffer=20,
                                 fun=mean, 
                                 df=TRUE)
 
-#view data
+# view data
 head(av_tree_height_tower)
 
-#how many pixels were extracted
+# how many pixels were extracted
 nrow(av_tree_height_tower)
 
 ```
@@ -519,21 +506,21 @@ Create a simple plot showing the mean tree height of each plot.
 
 ```{r challenge-code-extract-plot-tHeight, include=TRUE, results="hide", echo=FALSE}
 
-#first import the plot location file.
+# first import the plot location file.
 plot.locationsSp_HARV <- readOGR("NEON-DS-Site-Layout-Files/HARV/",
                             "PlotLocations_HARV")
 
-#extract data at each plot location
+# extract data at each plot location
 meanTreeHt_plots_HARV <- extract(x = chm_HARV, 
                                y = plot.locationsSp_HARV, 
                                buffer=20,
                                fun=mean, 
                                df=TRUE)
 
-#view data
+# view data
 meanTreeHt_plots_HARV
 
-#plot data
+# plot data
 plot(meanTreeHt_plots_HARV,
      main="MeanTree Height at each Plot\nNEON Harvard Forest Field Site",
      xlab="Plot ID", ylab="Tree Height (m)",


### PR DESCRIPTION
- Added space in comments
- Deleted the vector series section in Grey Box.  While how we eventually deal with this is still a bit up in the air, the text and links here were incorrect.  Raster and time-series does not have this text at this point.  If we want to add it back in, the un-used _include files in NEON-Data-Skills-Development are updated with text and links.  
